### PR TITLE
paper1: Fix erroneous arm length formula

### DIFF
--- a/paper1/paper1.tex
+++ b/paper1/paper1.tex
@@ -111,7 +111,7 @@ A cubic B{\'e}zier has two internal control points. Both must lie on the line ta
 
 \[
 \begin{aligned}
-\mbox{arm length} & = \tfrac{5}{12}(\sin \theta_a - 0.2\sin 3\theta_a), \quad \mbox{\emph{where}} \\
+\mbox{arm length} & = \tfrac{5}{12}(\cos \theta_a - 0.2\cos 3\theta_a), \quad \mbox{\emph{where}} \\
 \theta_a & = \theta_0 - 0.3 \sin (2\theta_1 - 0.4\sin 2\theta_1) \\
 \end{aligned}
 \]


### PR DESCRIPTION
This pull request replaces the two instances of `sin` in the formula for the arm length with `cos`.

There must've been a mix-up while this was written up, as the code uses `cos`:
<https://github.com/raphlinus/spline-research/blob/1a0fd3df09db517726309e899f165dc225e466e3/curves.js#L219>
Now, paper and code match.

(If one were to use `sin` as originally written, the arm length has the wrong sign most (if not all) the time. Even if one fixes that, the resulting curve behaves rather weirdly; I noticed this while trying to implement this curve for use with my pen plotter.)

Best, and thanks for the write-up,
Lukas